### PR TITLE
🚧 Make `auth.hook()` compatible with multiple `octokit.hook.wrap("request", ...)` calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1987,6 +1987,47 @@
         "fastq": "^1.6.0"
       }
     },
+    "@octokit/auth-token": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.0.tgz",
+      "integrity": "sha512-eoOVMjILna7FVQf96iWc3+ZtE/ZT6y8ob8ZzcqKY1ibSQCnu4O/B7pJvzMx5cyZ/RjAff6DAdEb0O0Cjcxidkg==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^2.0.0"
+      }
+    },
+    "@octokit/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-RoT3CIjYnamARpMkT5vqc+tV7p46ThItEZfWVXnskqKIoeBZMZLwAQGK0nudN3NocCvIIBSzII5r/ep7lr/0Qg==",
+      "dev": true,
+      "requires": {
+        "@octokit/auth-token": "^2.4.0",
+        "@octokit/graphql": "^4.3.1",
+        "@octokit/request": "^5.3.1",
+        "@octokit/types": "^2.0.0",
+        "before-after-hook": "^2.1.0",
+        "universal-user-agent": "^4.0.0"
+      },
+      "dependencies": {
+        "@octokit/request": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.1.tgz",
+          "integrity": "sha512-5/X0AL1ZgoU32fAepTfEoggFinO3rxsMLtzhlUX+RctLrusn/CApJuGFCd0v7GMFhF+8UiCsTTfsu7Fh1HnEJg==",
+          "dev": true,
+          "requires": {
+            "@octokit/endpoint": "^5.5.0",
+            "@octokit/request-error": "^1.0.1",
+            "@octokit/types": "^2.0.0",
+            "deprecation": "^2.0.0",
+            "is-plain-object": "^3.0.0",
+            "node-fetch": "^2.3.0",
+            "once": "^1.4.0",
+            "universal-user-agent": "^4.0.0"
+          }
+        }
+      }
+    },
     "@octokit/endpoint": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.0.tgz",
@@ -2007,6 +2048,17 @@
             "@types/node": "^12.11.1"
           }
         }
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.3.1.tgz",
+      "integrity": "sha512-hCdTjfvrK+ilU2keAdqNBWOk+gm1kai1ZcdjRfB30oA3/T6n53UVJb7w0L5cR3/rhU91xT3HSqCd+qbvH06yxA==",
+      "dev": true,
+      "requires": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^2.0.0",
+        "universal-user-agent": "^4.0.0"
       }
     },
     "@octokit/request": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@octokit/types": "^2.0.0"
   },
   "devDependencies": {
+    "@octokit/core": "^2.2.0",
     "@octokit/request": "^5.3.0",
     "@pika/pack": "^0.5.0",
     "@pika/plugin-build-node": "^0.8.1",

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -16,6 +16,10 @@ export async function hook(
   route: Route | EndpointOptions,
   parameters?: RequestParameters
 ): Promise<AnyResponse> {
+  // If hookMethod is `@octokit/request`, then use its `.endpoint` method so that its
+  // defaults are inherrited. But if no `.endpoint` method is set, it most likely means
+  // that the hook was not passed as first hook to `octokit.hook.wrap("request", hook)`,
+  // in which case `hookMethod` is a pre-bound method without the .endpoint key.
   const endpoint: EndpointDefaults =
     "endpoint" in hookMethod
       ? hookMethod.endpoint.merge(route as string, parameters)

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -12,16 +12,16 @@ import { withAuthorizationPrefix } from "./with-authorization-prefix";
 
 export async function hook(
   token: Token,
-  request: RequestInterface,
+  hookMethod: RequestInterface | Function,
   route: Route | EndpointOptions,
   parameters?: RequestParameters
 ): Promise<AnyResponse> {
-  const endpoint: EndpointDefaults = request.endpoint.merge(
-    route as string,
-    parameters
-  );
+  const endpoint: EndpointDefaults =
+    "endpoint" in hookMethod
+      ? hookMethod.endpoint.merge(route as string, parameters)
+      : (route as EndpointDefaults);
 
   endpoint.headers.authorization = withAuthorizationPrefix(token);
 
-  return request(endpoint as EndpointOptions);
+  return hookMethod(endpoint as EndpointOptions);
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,3 +1,4 @@
+import { Octokit } from "@octokit/core";
 import { request } from "@octokit/request";
 import fetchMock, { MockMatcherFunction } from "fetch-mock";
 
@@ -181,6 +182,40 @@ test("auth.hook() with JWT", async () => {
     "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOi0zMCwiZXhwIjo1NzAsImlzcyI6MX0.q3foRa78U3WegM5PrWLEh5N0bH1SD62OqW66ZYzArp95JBNiCbo8KAlGtiRENCIfBZT9ibDUWy82cI4g3F09mdTq3bD1xLavIfmTksIQCz5EymTWR5v6gL14LSmQdWY9lSqkgUG0XCFljWUglEP39H4yeHbFgdjvAYg3ifDS12z9oQz2ACdSpvxPiTuCC804HkPVw8Qoy0OSXvCkFU70l7VXCVUxnuhHnk8-oCGcKUspmeP6UdDnXk-Aus-eGwDfJbU2WritxxaXw6B4a3flTPojkYLSkPBr6Pi0H2-mBsW_Nvs0aLPVLKobQd4gqTkosX3967DoAG8luUMhrnxe8Q"
   );
   const { data } = await hook(requestMock, "GET /user");
+
+  expect(data).toStrictEqual({ id: 123 });
+});
+
+test('octokit.hook.wrap("request", auth.hook)', async () => {
+  const expectedRequestHeaders = {
+    accept: "application/vnd.github.v3+json",
+    authorization: "token 1234567890abcdef1234567890abcdef12345678"
+  };
+
+  const matchGetUser: MockMatcherFunction = (url, { body, headers }) => {
+    expect(url).toEqual("https://api.github.com/user");
+    expect(headers).toMatchObject(expectedRequestHeaders);
+    // @ts-ignore
+    expect(headers["user-agent"]).toMatch(/^test /);
+    return true;
+  };
+
+  const octokit = new Octokit({
+    userAgent: "test",
+    request: {
+      fetch: fetchMock.sandbox().getOnce(matchGetUser, { id: 123 })
+    }
+  });
+
+  const { hook } = createTokenAuth("1234567890abcdef1234567890abcdef12345678");
+
+  octokit.hook.wrap("request", (method, options) => {
+    return method(options);
+  });
+
+  // @ts-ignore
+  octokit.hook.wrap("request", hook);
+  const { data } = await octokit.request("GET /user");
 
   expect(data).toStrictEqual({ id: 123 });
 });


### PR DESCRIPTION
I'll hold off merging this until I reviewed the other authentication strategies for the same problem